### PR TITLE
Add tag list to machine collections

### DIFF
--- a/app/controllers/api/v0/machine_collections_controller.rb
+++ b/app/controllers/api/v0/machine_collections_controller.rb
@@ -1,6 +1,6 @@
 class Api::V0::MachineCollectionsController < ApplicationController
   def index
-    render json: MachineCollectionSerializer.new(MachineCollection.all)
+    render json: MachineCollectionSerializer.new(MachineCollection.all.includes(:taggings))
   end
 
   def show
@@ -19,5 +19,5 @@ end
 private
 
 def machine_collection_params
-  params.permit(:title, :user_id)
+  params.permit(:title, :tag_list, :user_id)
 end

--- a/app/serializers/machine_collection_serializer.rb
+++ b/app/serializers/machine_collection_serializer.rb
@@ -1,4 +1,4 @@
 class MachineCollectionSerializer
   include FastJsonapi::ObjectSerializer
-  attributes :title
+  attributes :title, :tag_list
 end

--- a/spec/requests/api/v0/machine_collection_spec.rb
+++ b/spec/requests/api/v0/machine_collection_spec.rb
@@ -3,20 +3,19 @@ require "rails_helper"
 RSpec.describe "Api::V0::MachineCollections" do
   it "can get all machine_collections" do
     user = create(:user, username: "ben", summary: "Something something")
-    user.machine_collections.create!(title: "Best of JS")
-    user.machine_collections.create!(title: "Best of Ruby")
+    user.machine_collections.create!(title: "Best of JS", tag_list: %w[Java Javascript])
+    user.machine_collections.create!(title: "Best of Ruby", tag_list: %w[Rails Ruby])
 
     get "/api/v0/machine_collections"
 
     expect(response).to be_successful
-
     collections = JSON.parse(response.body, symbolize_names: true)[:data]
     expect(collections.count).to eq(2)
   end
 
   it "can get one machine_collection by its ID" do
     user = create(:user, username: "ben", summary: "Something something")
-    collection1 = user.machine_collections.create!(title: "Best of JS")
+    collection1 = user.machine_collections.create!(title: "Best of JS", tag_list: %w[Java Javascript])
     user.machine_collections.create!(title: "Best of Ruby")
     id = collection1.id
 
@@ -26,14 +25,15 @@ RSpec.describe "Api::V0::MachineCollections" do
 
     collection = JSON.parse(response.body, symbolize_names: true)[:data]
     expect(collection[:id].to_i).to eq(id)
+    expect(collection[:attributes][:tag_list].first).to eq("Java")
   end
 
   it "can update a machine_collection's title" do
     user = create(:user, username: "ben", summary: "Something something")
-    collection1 = user.machine_collections.create!(title: "Best of JS")
+    collection1 = user.machine_collections.create!(title: "Best of JS", tag_list: %w[Java Javascript])
     id = collection1.id
     previous_title = MachineCollection.last.title
-    collection_params = { title: "Alex Rules, JS Drools" }
+    collection_params = { title: "Alex Rules, JS Drools", tag_list: %w[Rails Ruby] }
 
     patch "/api/v0/machine_collections/#{id}", params: collection_params
 
@@ -46,7 +46,7 @@ RSpec.describe "Api::V0::MachineCollections" do
 
   it "can delete a machine_collection" do
     user = create(:user, username: "ben", summary: "Something something")
-    collection1 = user.machine_collections.create!(title: "Best of JS")
+    collection1 = user.machine_collections.create!(title: "Best of JS", tag_list: %w[Java Javascript])
     user.machine_collections.create!(title: "Best of Ruby")
 
     expect(MachineCollection.count).to eq(2)


### PR DESCRIPTION
Working to add tag_list to all machine collections and have them move throughout MVC to work in all CRUD endpoints.